### PR TITLE
【bugfix】修复键盘弹起引起的页面高度变化，弹幕区未发生变化的bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 ios/.generated/
 ios/Flutter/Generated.xcconfig
 ios/Runner/GeneratedPluginRegistrant.*
+
+.idea
+android/local.properties

--- a/lib/flutter_barrage.dart
+++ b/lib/flutter_barrage.dart
@@ -108,7 +108,7 @@ class _BarrageState extends State<BarrageWall> with TickerProviderStateMixin {
   int _processed = 0;
   double? _width;
   double? _height;
-  double? _lastHeight; // 上一次计算通道跟书的的高度记录
+  double? _lastHeight; // 上一次计算通道个数的的高度记录
   late Timer _cleaner;
 
   int _usedChannel = 0;

--- a/lib/flutter_barrage.dart
+++ b/lib/flutter_barrage.dart
@@ -108,6 +108,7 @@ class _BarrageState extends State<BarrageWall> with TickerProviderStateMixin {
   int _processed = 0;
   double? _width;
   double? _height;
+  double? _lastHeight; // 上一次计算通道跟书的的高度记录
   late Timer _cleaner;
 
   int _usedChannel = 0;
@@ -271,7 +272,9 @@ class _BarrageState extends State<BarrageWall> with TickerProviderStateMixin {
         return;
       }
 
-      if (_totalChannels == null) {
+      if (_totalChannels == null ||
+          (_totalChannels != null && _lastHeight != _height)) {
+        _lastHeight = _height;
         _maxBulletHeight = widget.maxBulletHeight;
         _totalChannels = _calcSafeHeight(_height!) ~/ _maxBulletHeight!;
         _channelMask = (2 << _totalChannels!) - 1;


### PR DESCRIPTION
键盘弹出，height变小了，此时接收到弹幕时，根据此时的高度计算通道个数。
键盘收起时，因为通道个数已经计算出，不会重复计算，导致弹幕一直在页面上方位置。
增加了高度变化，重置通道个数的逻辑判断